### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Want to get the most out of Snipaste?
 
 Beta for Mac!
 - Download: <a href="https://dl.snipaste.com/mac-beta"><img src="https://badgen.net/https/snipaste.com/mac_version?icon=apple" /></a>
-- Or install via brew cast: `brew cask install snipaste`
+- Or install via brew cast: `brew install --cask snipaste`
 
 ## Feedback
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524